### PR TITLE
Add NPM release action

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,77 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0 on 2025-08-11
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag is on main branch
+        shell: bash
+        run: |
+          git fetch origin main
+
+          # Check if the current commit (tag) is reachable from master
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "Error: Tag ${{ github.ref_name }} is not on the main branch"
+            echo "Tags can only be published from commits that exist on main"
+            exit 1
+          fi
+          echo "✅ Tag ${{ github.ref_name }} is on main branch"
+
+      - name: Validate tag format
+        shell: bash
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "Publishing tag: $TAG"
+          if [[ ! $TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-beta(\.[0-9]+)?)?$ ]]; then
+            echo "Invalid tag format. Expected: v1.2.3 or v1.2.3-beta or v1.2.3-beta.1"
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0 on 2025-09-02
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Determine npm tag
+        id: npm-tag
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$TAG" == *"-beta"* ]]; then
+            echo "tag=beta" >> $GITHUB_OUTPUT
+            echo "Publishing as beta release"
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "Publishing as latest release"
+          fi
+
+      - name: Publish release to NPM
+        shell: bash
+        run: |
+          echo "About to run: npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}"
+          npm publish --provenance --tag ${{ steps.npm-tag.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Build and Test
 on:
   merge_group:
   workflow_dispatch:
+  workflow_call:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
### Description

This PR adds a GitHub Action workflow that automatically published the package to NPM when the following conditions are met:

1. Tests pass
2. Repository is properly tagged
3. Tag is on `main`

### Testing

This action will not run on the branch being proposed in the PR, so the testing strategy is:

1. Merge PR
2. Make sure NPM secrets are correct
3. Change action in a new PR if it does not work on `main`

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
