### PR TITLE
Use auth0 namespace in the package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "auth0-checkmate",
-  "version": "1.3.0",
+  "name": "@auth0/auth0-checkmate",
+  "version": "1.4.0",
   "description": "A command line tool for checking configuration of your Auth0 tenant",
   "main": "analyzer/report.js",
   "scripts": {


### PR DESCRIPTION
### Description

This PR publishes the package to NPM with the name `@auth0/auth0-checkmate`.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
