### PR TITLE
fix: update publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "proxyquire": "^2.1.3",
     "sinon": "^19.0.2"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/auth0/auth0-checkmate.git"


### PR DESCRIPTION
fix the publishing error:
npm error Can't generate provenance for new or private package, you must set `access` to public.

Address publishing issue shown here: https://github.com/auth0/auth0-checkmate/actions/runs/17868570134/job/50816863824.