### PR TITLE
Bump version to match git tag for first NPM release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-checkmate",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A command line tool for checking configuration of your Auth0 tenant",
   "main": "analyzer/report.js",
   "scripts": {


### PR DESCRIPTION
### Description

This PR bumps the version in `auth0-checkmate` to match what's in GitHub.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
