### PR TITLE
Bump release to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@auth0/auth0-checkmate",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-checkmate",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-checkmate",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A command line tool for checking configuration of your Auth0 tenant",
   "main": "analyzer/report.js",
   "scripts": {


### PR DESCRIPTION
### Description

This PR bumps the version of CheckMate for Auth0 for releasing a new version to npm.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
