### PR TITLE
fix(security): run npm ci with --ignore-scripts

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -53,7 +53,7 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Determine npm tag
         id: npm-tag


### PR DESCRIPTION
This would avoid malicious scripts in vulnerable packages to be executed on CI