### PR TITLE
fix: replace puppeteer with puppeteer-core + @sparticuz/chromium for PDF generation

### DIFF
--- a/analyzer/report.js
+++ b/analyzer/report.js
@@ -3,7 +3,8 @@ const i18n = require("i18n");
 const path = require("path");
 const _ = require("lodash");
 const Handlebars = require("handlebars");
-const puppeteer = require("puppeteer");
+const puppeteer = require("puppeteer-core");
+const chromium = require("@sparticuz/chromium");
 const listOfAnalyser = require("./lib/listOfAnalyser");
 const {
   getAccessToken,
@@ -474,11 +475,9 @@ async function generatePdfBuffer(report, auth0Domain, locale) {
   const data = { report, auth0Domain, today, locale, version, config: {} };
 
   const browser = await puppeteer.launch({
-    headless: true, // Run in headless mode
-    args: [
-      "--no-sandbox", // Disable the sandbox
-      "--disable-setuid-sandbox", // Disable setuid sandbox
-    ],
+    args: chromium.args,
+    executablePath: await chromium.executablePath(),
+    headless: chromium.headless,
   });
 
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1166,7 +1166,7 @@
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
       "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1197,7 +1197,7 @@
     },
     "node_modules/@sparticuz/chromium": {
       "version": "147.0.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/@sparticuz/chromium/-/chromium-147.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-147.0.0.tgz",
       "integrity": "sha512-4ZKeAQQa8up2mt675qSitztLdbQrlf8BKdC5naeap+5Mv1OV1OlJdPoU+EJC/p5sQUJUQmN4r+q5+EhaaOUHpQ==",
       "license": "MIT",
       "dependencies": {
@@ -1758,7 +1758,7 @@
     },
     "node_modules/chromium-bidi": {
       "version": "14.0.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
       "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1972,7 +1972,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "license": "MIT",
       "dependencies": {
@@ -2104,7 +2104,7 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1581282",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "license": "BSD-3-Clause"
     },
@@ -2177,7 +2177,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
       "engines": {
@@ -2186,7 +2186,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/error-ex/-/error-ex-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
@@ -3269,7 +3269,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
@@ -3546,7 +3546,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
@@ -3652,7 +3652,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
@@ -4498,7 +4498,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
       "dependencies": {
@@ -4747,7 +4747,7 @@
     },
     "node_modules/puppeteer": {
       "version": "24.40.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/puppeteer/-/puppeteer-24.40.0.tgz",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.40.0.tgz",
       "integrity": "sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -4768,7 +4768,7 @@
     },
     "node_modules/puppeteer-core": {
       "version": "24.40.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
       "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -4957,7 +4957,7 @@
     },
     "node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/semver/-/semver-7.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
@@ -5284,7 +5284,7 @@
     },
     "node_modules/tar-fs": {
       "version": "3.1.2",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/tar-fs/-/tar-fs-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
       "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "license": "MIT",
       "dependencies": {
@@ -5409,7 +5409,7 @@
     },
     "node_modules/typed-query-selector": {
       "version": "2.12.1",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
       "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
       "license": "MIT"
     },
@@ -5502,7 +5502,7 @@
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
       "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "license": "Apache-2.0"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "@auth0/auth0-checkmate",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@auth0/auth0-checkmate",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@sparticuz/chromium": "^147.0.0",
         "acorn": "^8.14.0",
         "axios": "^1.13.5",
         "chalk": "^4.1.2",
@@ -22,7 +23,8 @@
         "jsonwebtoken": "^9.0.3",
         "lodash": "^4.18.1",
         "moment": "^2.30.1",
-        "puppeteer": "^24.36.0",
+        "puppeteer": "^24.40.0",
+        "puppeteer-core": "^24.40.0",
         "semver": "^7.7.3",
         "winston": "^3.19.0"
       },
@@ -1163,16 +1165,16 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.1.tgz",
-      "integrity": "sha512-YmhAxs7XPuxN0j7LJloHpfD1ylhDuFmmwMvfy/+6nBSrETT2ycL53LrhgPtR+f+GcPSybQVuQ5inWWu5MrWCpA==",
+      "version": "2.13.0",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "tar-fs": "^3.1.1",
         "yargs": "^17.7.2"
       },
@@ -1191,6 +1193,19 @@
       "dependencies": {
         "color": "^5.0.2",
         "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@sparticuz/chromium": {
+      "version": "147.0.0",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/@sparticuz/chromium/-/chromium-147.0.0.tgz",
+      "integrity": "sha512-4ZKeAQQa8up2mt675qSitztLdbQrlf8BKdC5naeap+5Mv1OV1OlJdPoU+EJC/p5sQUJUQmN4r+q5+EhaaOUHpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "tar-fs": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=20.11.0"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -1742,9 +1757,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
-      "integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
+      "version": "14.0.0",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
@@ -1956,9 +1971,9 @@
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "version": "9.0.1",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -2088,9 +2103,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1551306",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
-      "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
+      "version": "0.0.1581282",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+      "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
@@ -2162,7 +2177,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
       "engines": {
@@ -2171,7 +2186,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
@@ -3254,7 +3269,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
@@ -3531,7 +3546,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
@@ -3637,7 +3652,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
@@ -4483,7 +4498,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
       "dependencies": {
@@ -4731,18 +4746,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.36.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.36.0.tgz",
-      "integrity": "sha512-BD/VCyV/Uezvd6o7Fd1DmEJSxTzofAKplzDy6T9d4WbLTQ5A+06zY7VwO91ZlNU22vYE8sidVEsTpTrKc+EEnQ==",
+      "version": "24.40.0",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/puppeteer/-/puppeteer-24.40.0.tgz",
+      "integrity": "sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.1",
-        "chromium-bidi": "13.0.1",
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1551306",
-        "puppeteer-core": "24.36.0",
-        "typed-query-selector": "^2.12.0"
+        "devtools-protocol": "0.0.1581282",
+        "puppeteer-core": "24.40.0",
+        "typed-query-selector": "^2.12.1"
       },
       "bin": {
         "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -4752,17 +4767,17 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.36.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.0.tgz",
-      "integrity": "sha512-P3Ou0MAFDCQ0dK1d9F9+8jTrg6JvXjUacgG0YkJQP4kbEnUOGokSDEMmMId5ZhXD5HwsHM202E9VwEpEjWfwxg==",
+      "version": "24.40.0",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
+      "integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.1",
-        "chromium-bidi": "13.0.1",
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1551306",
-        "typed-query-selector": "^2.12.0",
-        "webdriver-bidi-protocol": "0.4.0",
+        "devtools-protocol": "0.0.1581282",
+        "typed-query-selector": "^2.12.1",
+        "webdriver-bidi-protocol": "0.4.1",
         "ws": "^8.19.0"
       },
       "engines": {
@@ -4941,9 +4956,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5268,9 +5283,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.1.2",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -5393,9 +5408,9 @@
       }
     },
     "node_modules/typed-query-selector": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "version": "2.12.1",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
+      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
       "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
@@ -5486,9 +5501,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
-      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
+      "version": "0.4.1",
+      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
       "license": "Apache-2.0"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@auth0/auth0-checkmate",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A command line tool for checking configuration of your Auth0 tenant",
   "main": "analyzer/report.js",
   "scripts": {
@@ -16,6 +16,7 @@
     "node": ">=20.18.3"
   },
   "dependencies": {
+    "@sparticuz/chromium": "^147.0.0",
     "acorn": "^8.14.0",
     "axios": "^1.13.5",
     "chalk": "^4.1.2",
@@ -29,7 +30,8 @@
     "jsonwebtoken": "^9.0.3",
     "lodash": "^4.18.1",
     "moment": "^2.30.1",
-    "puppeteer": "^24.36.0",
+    "puppeteer": "^24.40.0",
+    "puppeteer-core": "^24.40.0",
     "semver": "^7.7.3",
     "winston": "^3.19.0"
   },


### PR DESCRIPTION
Puppeteer bundles its own Chromium and creates a temp Chrome profile directory under `os.tmpdir() (/tmp)` at launch time. 

Production containers mount /tmp as read-only (EROFS), causing PDF generation to crash with: EROFS: read-only file system, `mkdtemp '/tmp/puppeteer_dev_chrome_profile-*'`

@sparticuz/chromium is a pre-built Chromium binary designed for containerised/serverless environments. It manages its own extraction path and does not rely on /tmp being writable. puppeteer-core is used instead of the full puppeteer package for the server-side report.js. The CLI (bin/index.js) retains the original puppeteer dependency.

Bumps version to 1.7.2 (patch).