### PR TITLE
Backchannel logout

### DIFF
--- a/analyzer/lib/clients/checkBackchannelLogout.js
+++ b/analyzer/lib/clients/checkBackchannelLogout.js
@@ -1,0 +1,97 @@
+/*
+{
+  clients: [
+  {
+    "tenant": "contoso",
+    "global": false,
+    "name": "backchannellogout",
+    "client_id": "client_id",
+    "app_type": "regular_web",
+    "grant_types": [
+      "authorization_code",
+      "refresh_token"
+    ],
+    "oidc_backchannel_logout": {
+      "backchannel_logout_initiators": {
+        "mode": "all"
+      },
+      "backchannel_logout_urls": [
+        "https://example.com/backchannel-logout"
+      ]
+    }
+  }
+  ]
+}
+
+Back-Channel Logout is only relevant for applications that maintain server-side sessions
+and can receive back-channel communications. It is applicable to regular_web apps.
+SPAs and native apps use front-channel logout and cannot receive back-channel requests.
+Non-interactive (M2M) clients do not have user sessions and are not relevant.
+*/
+const _ = require("lodash");
+const executeCheck = require("../executeCheck");
+const CONSTANTS = require("../constants");
+
+const BACKCHANNEL_LOGOUT_APP_TYPES = ["regular_web"];
+
+function validateBackchannelLogoutForApp(app) {
+    const report = [];
+
+    // Check both oidc_backchannel_logout and oidc_logout fields
+    const backchannelConfig = app.oidc_backchannel_logout || app.oidc_logout;
+    const backchannelUrls =
+        backchannelConfig?.backchannel_logout_urls || [];
+
+    if (!backchannelConfig || backchannelUrls.length === 0) {
+        report.push({
+            name: app.client_id ? app.name.concat(` (${app.client_id})`) : app.name,
+            client_id: app.client_id,
+            field: "oidc_backchannel_logout.backchannel_logout_urls",
+            status: CONSTANTS.FAIL,
+            value: "not_configured",
+            is_first_party: app.is_first_party,
+        });
+    } else {
+        report.push({
+            name: app.client_id ? app.name.concat(` (${app.client_id})`) : app.name,
+            client_id: app.client_id,
+            field: "oidc_backchannel_logout.backchannel_logout_urls",
+            status: CONSTANTS.SUCCESS,
+            value: backchannelUrls.join(", "),
+            is_first_party: app.is_first_party,
+        });
+    }
+
+    return report;
+}
+
+function checkBackchannelLogout(options) {
+    return executeCheck("checkBackchannelLogout", (callback) => {
+        const { clients } = options || [];
+        const reports = [];
+
+        if (_.isEmpty(clients)) {
+            return callback(reports);
+        }
+
+        clients.forEach((client) => {
+            // Skip global/system clients
+            if (client.global) {
+                return;
+            }
+
+            // Only check app types that support back-channel logout
+            if (!BACKCHANNEL_LOGOUT_APP_TYPES.includes(client.app_type)) {
+                return;
+            }
+
+            const report = validateBackchannelLogoutForApp(client);
+            const name = client.name.concat(` (${client.client_id})`);
+            reports.push({ name: name, report: report });
+        });
+
+        return callback(reports);
+    });
+}
+
+module.exports = checkBackchannelLogout;

--- a/locales/en.json
+++ b/locales/en.json
@@ -1604,7 +1604,7 @@
 				"Ensure your client application is updated to send authorization parameters via the PAR endpoint (/oauth/par) before initiating the authorization redirect."
 			]
 		},
-		"severity_message": "%s applications / clients do not require Pushed Authorization Requests (PAR)",
+		"severity_message": "%s applications / clients do not have Pushed Authorization Requests (PAR) configured",
 		"require_pushed_authorization_requests": "Pushed Authorization Requests (PAR) is not required for this application (require_pushed_authorization_requests: %s)",
 		"undefined": "Pushed Authorization Requests (PAR) is not required for this application"
 	},
@@ -1634,7 +1634,7 @@
 				"Update your client application to sign authorization requests as JWTs using your registered private key before sending them to the authorization endpoint."
 			]
 		},
-		"severity_message": "%s applications / clients do not require JWT Authorization Requests (JAR)",
+		"severity_message": "%s applications / clients do not have JWT Authorization Requests (JAR) configured",
 		"signed_request_object.required": "JWT Authorization Requests (JAR) are not required for this application (signed_request_object.required: %s)",
 		"signed_request_object.credentials": "JWT Authorization Requests (JAR) is required but no signing credentials are configured for this application. JAR cannot function without a registered public key.",
 		"undefined": "JWT Authorization Requests (JAR) are not required for this application"
@@ -1738,7 +1738,7 @@
 	"checkBackchannelLogout": {
         "title": "Applications - Back-Channel Logout",
         "category": "Applications",
-        "description": "Back-Channel Logout enables the identity provider to directly notify applications when a session is terminated, ensuring that all sessions across applications are invalidated immediately. Auth0 supports the OpenID Connect Back-Channel Logout 1.0 specification, which leverages session IDs (sid) in ID tokens and Logout Tokens to coordinate session termination via back-channel communication.",
+        "description": "Back-Channel Logout enables the identity provider to directly notify applications when a session is terminated, ensuring that all application sessions are invalidated immediately. Auth0 supports the OpenID Connect Back-Channel Logout 1.0 specification, which leverages session IDs (sid) in ID tokens and Logout Tokens to coordinate session termination via back-channel communication.",
         "docsPath": [
             "https://auth0.com/docs/authenticate/login/logout/back-channel-logout"
         ],

--- a/locales/en.json
+++ b/locales/en.json
@@ -54,7 +54,8 @@
 				"Token Sender-Constraining",
 				"Pushed Authorization Requests (PAR)",
 				"JWT Authorization Requests (JAR)",
-				"Private Key JWT"
+				"Private Key JWT",
+				"Back-Channel Logout"
 			]
 		},
 		{
@@ -1733,5 +1734,36 @@
 		"severity_message": "%s applications / clients do not have Private Key JWT configured",
 		"client_authentication_methods.private_key_jwt": "Private Key JWT is not configured for this application. Consider using Private Key JWT instead of a client secret for stronger client authentication.",
 		"undefined": "Private Key JWT authentication method is not configured for this application"
-	}
+	},
+	"checkBackchannelLogout": {
+        "title": "Applications - Back-Channel Logout",
+        "category": "Applications",
+        "description": "Back-Channel Logout enables the identity provider to directly notify applications when a session is terminated, ensuring that all sessions across applications are invalidated immediately. Auth0 supports the OpenID Connect Back-Channel Logout 1.0 specification, which leverages session IDs (sid) in ID tokens and Logout Tokens to coordinate session termination via back-channel communication.",
+        "docsPath": [
+            "https://auth0.com/docs/authenticate/login/logout/back-channel-logout"
+        ],
+        "severity": "Moderate",
+        "status": "yellow",
+        "disclaimer": "Back-Channel Logout is available only to customers on an Enterprise plan subscription.",
+        "advisory": {
+            "issue": "Back-Channel Logout URI Not Configured for Application",
+            "description": {
+                "what_it_is": "Back-Channel Logout (OIDC Back-Channel Logout 1.0) allows the Auth0 tenant to directly call a pre-registered logout URI on your application server when a user session is terminated — without relying on the user's browser. The tenant sends a signed Logout Token containing the user's sub and sid claims, which the application uses to identify and terminate the corresponding local session. This enables centralized, reliable session revocation across all applications sharing the same Auth0 session.",
+                "why_its_risky": [
+                    "Without Back-Channel Logout, application sessions may remain active even after the user logs out of Auth0, leaving a window for session hijacking or unauthorized access.",
+                    "Front-channel logout relies on the user's browser completing redirects — if the browser is closed, network issues occur, or redirects are blocked, applications may never receive the logout signal.",
+                    "In multi-application environments, a logout from one application will not propagate to others without back-channel coordination, violating the principle of centralized session control."
+                ]
+            },
+            "how_to_fix": [
+                "In the Auth0 Dashboard, navigate to Applications > [Your App] > OpenID Connect Back-Channel Logout and configure a Back-Channel Logout URI that is reachable from the Auth0 tenant server.",
+                "Implement the logout endpoint to validate the incoming Logout Token: verify the issuer, audience, signature, expiry, and that the events claim contains 'http://schemas.openid.net/event/backchannel-logout'.",
+                "Store the session ID (sid) received in ID tokens during login so it can be matched against incoming Logout Tokens.",
+                "Extract the sid claim from the Logout Token and use it to locate and terminate the matching local application session."
+            ]
+        },
+        "severity_message": "%s applications do not have Back-Channel Logout configured",
+        "oidc_backchannel_logout.backchannel_logout_urls": "Back-Channel Logout is not configured for this application. Consider adding a Back-Channel Logout URI to ensure reliable session termination across all applications.",
+        "undefined": "Back-Channel Logout URI is not configured for this application"
+    }
 }

--- a/tests/clients/checkBackchannelLogout.test.js
+++ b/tests/clients/checkBackchannelLogout.test.js
@@ -1,0 +1,219 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const checkBackchannelLogout = require("../../analyzer/lib/clients/checkBackchannelLogout");
+const CONSTANTS = require("../../analyzer/lib/constants");
+
+describe("checkBackchannelLogout", function () {
+
+    it("should return an empty report when no clients are provided", function () {
+        const options = { clients: [] };
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").that.is.empty;
+        });
+    });
+
+    it("should skip global clients", function () {
+        const options = {
+            clients: [{
+                name: "All Applications",
+                client_id: "global_client",
+                global: true,
+                app_type: "regular_web",
+                is_first_party: true,
+            }],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").that.is.empty;
+        });
+    });
+
+    it("should skip SPA clients", function () {
+        const options = {
+            clients: [{
+                name: "SPA App",
+                client_id: "client_spa",
+                global: false,
+                is_first_party: true,
+                app_type: "spa",
+                grant_types: ["authorization_code", "refresh_token"],
+            }],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").that.is.empty;
+        });
+    });
+
+    it("should skip native clients", function () {
+        const options = {
+            clients: [{
+                name: "Mobile App",
+                client_id: "client_native",
+                global: false,
+                is_first_party: true,
+                app_type: "native",
+                grant_types: ["authorization_code", "refresh_token"],
+            }],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").that.is.empty;
+        });
+    });
+
+    it("should skip non_interactive (M2M) clients", function () {
+        const options = {
+            clients: [{
+                name: "M2M App",
+                client_id: "client_m2m",
+                global: false,
+                is_first_party: true,
+                app_type: "non_interactive",
+                grant_types: ["client_credentials"],
+            }],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").that.is.empty;
+        });
+    });
+
+    it("should report failure for a regular_web app without back-channel logout configured", function () {
+        const options = {
+            clients: [{
+                name: "Web App",
+                client_id: "client_web",
+                global: false,
+                is_first_party: true,
+                app_type: "regular_web",
+                grant_types: ["authorization_code", "refresh_token"],
+            }],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").with.lengthOf(1);
+            expect(result.details[0].name).to.equal("Web App (client_web)");
+            expect(result.details[0].report).to.be.an("array").with.lengthOf(1);
+            expect(result.details[0].report[0]).to.include({
+                field: "oidc_backchannel_logout.backchannel_logout_urls",
+                status: CONSTANTS.FAIL,
+                value: "not_configured",
+            });
+        });
+    });
+
+    it("should report success for a regular_web app with oidc_backchannel_logout configured", function () {
+        const options = {
+            clients: [{
+                name: "backchannellogout",
+                client_id: "client_bcl",
+                global: false,
+                is_first_party: true,
+                app_type: "regular_web",
+                grant_types: ["authorization_code", "refresh_token"],
+                oidc_backchannel_logout: {
+                    backchannel_logout_initiators: { mode: "all" },
+                    backchannel_logout_urls: ["https://example.com/backchannel-logout"],
+                },
+            }],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").with.lengthOf(1);
+            expect(result.details[0].name).to.equal("backchannellogout (client_bcl)");
+            expect(result.details[0].report[0]).to.include({
+                field: "oidc_backchannel_logout.backchannel_logout_urls",
+                status: CONSTANTS.SUCCESS,
+            });
+        });
+    });
+
+    it("should report success for a regular_web app with oidc_logout configured", function () {
+        const options = {
+            clients: [{
+                name: "Web App OIDC Logout",
+                client_id: "client_oidc_logout",
+                global: false,
+                is_first_party: true,
+                app_type: "regular_web",
+                grant_types: ["authorization_code", "refresh_token"],
+                oidc_logout: {
+                    backchannel_logout_initiators: { mode: "all" },
+                    backchannel_logout_urls: ["https://example.com/backchannel-logout"],
+                },
+            }],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").with.lengthOf(1);
+            expect(result.details[0].report[0]).to.include({
+                field: "oidc_backchannel_logout.backchannel_logout_urls",
+                status: CONSTANTS.SUCCESS,
+            });
+        });
+    });
+
+    it("should report failure when oidc_backchannel_logout has empty backchannel_logout_urls", function () {
+        const options = {
+            clients: [{
+                name: "Partial Config App",
+                client_id: "client_partial",
+                global: false,
+                is_first_party: true,
+                app_type: "regular_web",
+                grant_types: ["authorization_code"],
+                oidc_backchannel_logout: {
+                    backchannel_logout_initiators: { mode: "all" },
+                    backchannel_logout_urls: [],
+                },
+            }],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            expect(result.details).to.be.an("array").with.lengthOf(1);
+            expect(result.details[0].report[0]).to.include({
+                field: "oidc_backchannel_logout.backchannel_logout_urls",
+                status: CONSTANTS.FAIL,
+                value: "not_configured",
+            });
+        });
+    });
+
+    it("should handle a mix of regular_web and non-eligible clients correctly", function () {
+        const options = {
+            clients: [
+                {
+                    name: "SPA",
+                    client_id: "client_spa",
+                    global: false,
+                    is_first_party: true,
+                    app_type: "spa",
+                    grant_types: ["authorization_code"],
+                },
+                {
+                    name: "Web App",
+                    client_id: "client_web",
+                    global: false,
+                    is_first_party: true,
+                    app_type: "regular_web",
+                    grant_types: ["authorization_code", "refresh_token"],
+                    oidc_backchannel_logout: {
+                        backchannel_logout_initiators: { mode: "all" },
+                        backchannel_logout_urls: ["https://example.com/backchannel-logout"],
+                    },
+                },
+            ],
+        };
+
+        checkBackchannelLogout(options).then((result) => {
+            // Only the regular_web client should appear
+            expect(result.details).to.be.an("array").with.lengthOf(1);
+            expect(result.details[0].name).to.equal("Web App (client_web)");
+            expect(result.details[0].report[0]).to.include({
+                status: CONSTANTS.SUCCESS,
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Description

Adds a checkBackchannelLogout validator that scans all regular_web application clients (the only app type capable of receiving server-to-server logout notifications) and flags any that have not configured an OIDC back-channel logout URL. Back-channel logout ensures that when a session is terminated at Auth0, the downstream app is immediately notified via a direct server-to-server POST.  This closes the risk of zombie sessions that remain active on the application server after the IdP session has ended.


### Testing

- [X ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X ] All active GitHub checks for tests, formatting, and security are passing
- [ X] The correct base branch is being used, if not the default branch
