### PR TITLE
adding pkce enforced validator

### DIFF
--- a/analyzer/lib/clients/checkPKCEEnforcement.js
+++ b/analyzer/lib/clients/checkPKCEEnforcement.js
@@ -1,0 +1,167 @@
+/*
+{
+  clients: [
+  {
+    "tenant": "contoso",
+    "global": false,
+    "name": "My SPA App",
+    "client_id": "client_spa",
+    "app_type": "spa",
+    "is_first_party": true,
+    "grant_types": [
+      "authorization_code",
+      "refresh_token"
+    ]
+  }
+  ],
+  actions: {
+    actions: [
+      {
+        "id": "action_id",
+        "name": "Enforce PKCE",
+        "supported_triggers": [{ "id": "post-login", "version": "v3" }],
+        "code": "exports.onExecutePostLogin = async (event, api) => { if (!event.request.query.code_challenge) { api.access.deny('PKCE required'); } };"
+      }
+    ]
+  }
+}
+
+For SPA and native app types using the authorization_code grant, PKCE must be enforced.
+Auth0 does not natively block non-PKCE authorization code requests for public clients,
+so enforcement must be implemented via a post-login Action that checks for the presence
+of event.request.query.code_challenge and calls api.access.deny when it is absent.
+
+Reference: https://support.auth0.com/center/s/article/Enforce-PKCE-with-Actions
+*/
+const _ = require("lodash");
+const executeCheck = require("../executeCheck");
+const CONSTANTS = require("../constants");
+const acorn = require("acorn");
+const walk = require("estree-walker").walk;
+
+const PKCE_APPLICABLE_GRANT_TYPES = ["authorization_code"];
+const PKCE_APPLICABLE_APP_TYPES = ["spa", "native"];
+
+function isPKCEApplicableClient(client) {
+  const grantTypes = client.grant_types || [];
+  const appType = client.app_type;
+  return (
+    PKCE_APPLICABLE_APP_TYPES.includes(appType) &&
+    grantTypes.some((g) => PKCE_APPLICABLE_GRANT_TYPES.includes(g))
+  );
+}
+
+function getMemberExpressionPath(expr) {
+  if (expr.type === "Identifier") return expr.name;
+  if (expr.type === "MemberExpression") {
+    const obj = getMemberExpressionPath(expr.object);
+    const prop = expr.property.name;
+    return obj ? `${obj}.${prop}` : prop;
+  }
+  return null;
+}
+
+/**
+ * Scans an Action's code for both event.request.query.code_challenge access
+ * and an api.access.deny call, which together indicate PKCE enforcement.
+ */
+function hasPKCEEnforcement(code, scriptName) {
+  let hasCodeChallenge = false;
+  let hasAccessDeny = false;
+
+  let ast;
+  try {
+    ast = acorn.parse(code || "", {
+      ecmaVersion: "latest",
+      locations: true,
+    });
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      console.error(
+        `[ACORN PARSE ERROR] Skipping script "${scriptName}" due to malformed code`
+      );
+      return false;
+    }
+    throw e;
+  }
+
+  walk(ast, {
+    enter(node) {
+      if (node.type === "MemberExpression") {
+        // Match direct access (event.request.query.code_challenge) or
+        // indirect access via intermediate variable (query.code_challenge,
+        // codeChallenge = query && query.code_challenge, etc.)
+        if (node.property.name === "code_challenge") {
+          hasCodeChallenge = true;
+        }
+      }
+      if (node.type === "CallExpression") {
+        const path = getMemberExpressionPath(node.callee);
+        if (path === "api.access.deny") {
+          hasAccessDeny = true;
+        }
+      }
+    },
+  });
+
+  return hasCodeChallenge && hasAccessDeny;
+}
+
+function checkPKCEEnforcement(options) {
+  return executeCheck("checkPKCEEnforcement", (callback) => {
+    const { clients, actions } = options || {};
+    const reports = [];
+
+    if (_.isEmpty(clients)) {
+      return callback(reports);
+    }
+
+    const pkceApplicableClients = clients.filter(isPKCEApplicableClient);
+
+    if (_.isEmpty(pkceApplicableClients)) {
+      return callback(reports);
+    }
+
+    const actionsList = _.isArray(actions)
+      ? actions
+      : (actions && actions.actions) || [];
+
+    const hasPKCEAction = actionsList.some((action) => {
+      const triggers = action.supported_triggers || [];
+      const isPostLogin = triggers.some((t) => t.id === "post-login");
+      if (!isPostLogin) return false;
+      if (action.status !== "built") return false;
+
+      try {
+        return hasPKCEEnforcement(action.code, action.name);
+      } catch (e) {
+        console.error(
+          `[CHECK ERROR] Skipping Action "${action.name}" due to error: ${e.message}`
+        );
+        return false;
+      }
+    });
+
+    pkceApplicableClients.forEach((client) => {
+      const name = client.name.concat(` (${client.client_id})`);
+      const report = [];
+
+      if (!hasPKCEAction) {
+        report.push({
+          name: name,
+          client_id: client.client_id,
+          field: "pkce_enforcement_action_missing",
+          status: CONSTANTS.FAIL,
+          value: client.app_type,
+          is_first_party: client.is_first_party,
+        });
+      }
+
+      reports.push({ name: name, report: report });
+    });
+
+    return callback(reports);
+  });
+}
+
+module.exports = checkPKCEEnforcement;

--- a/locales/en.json
+++ b/locales/en.json
@@ -55,7 +55,8 @@
 				"Pushed Authorization Requests (PAR)",
 				"JWT Authorization Requests (JAR)",
 				"Private Key JWT",
-				"Back-Channel Logout"
+				"Back-Channel Logout",
+				"PKCE Enforcement for Public Clients"
 			]
 		},
 		{
@@ -1656,6 +1657,35 @@
 		"signed_request_object.credentials": "JWT Authorization Requests (JAR) is required but no signing credentials are configured for this application. JAR cannot function without a registered public key.",
 		"undefined": "JWT Authorization Requests (JAR) are not required for this application"
 	},
+	"checkPKCEEnforcement": {
+		"title": "Applications - PKCE Enforcement for Public Clients",
+		"category": "Applications",
+		"description": "Auth0 does not natively block authorization code requests that omit the PKCE code_challenge parameter for SPA and native clients. PKCE must be enforced via a post-login Action that checks for the presence of event.request.query.code_challenge and calls api.access.deny when it is absent.",
+		"docsPath": [
+			"https://support.auth0.com/center/s/article/Enforce-PKCE-with-Actions"
+		],
+		"severity": "Low",
+		"status": "green",
+		"advisory": {
+			"issue": "PKCE Enforcement Action Missing for Public Client",
+			"description": {
+				"what_it_is": "PKCE (Proof Key for Code Exchange, RFC 7636) is an OAuth 2.0 extension that protects public clients (SPAs and native apps) against authorization code interception attacks. It requires the client to generate a one-time code_verifier and include a hashed code_challenge in the authorization request, which the authorization server verifies when exchanging the code for tokens. Auth0 does not enforce PKCE natively on public clients using the authorization_code grant — enforcement must be implemented via a post-login Action.",
+				"why_its_risky": [
+					"Without PKCE enforcement, a malicious actor who intercepts the authorization code can exchange it for tokens without possessing the original code_verifier.",
+					"SPA and native app clients are public clients that cannot securely store a client_secret, making them especially vulnerable to authorization code interception.",
+					"Auth0 allows non-PKCE authorization code requests for public clients by default, meaning the authorization code grant is not protected unless enforcement is explicitly added.",
+					"Modern security best practices (OAuth 2.1, FAPI 2.0) require PKCE for all authorization code flows, regardless of client type."
+				]
+			},
+			"how_to_fix": [
+				"Create a post-login Action that checks for the presence of event.request.query.code_challenge in the authorization request and calls api.access.deny() when the parameter is absent.",
+				"Ensure all SPA and native application clients send a code_challenge and code_challenge_method in every authorization request."
+			]
+		},
+		"severity_message": "%s applications / clients are missing a PKCE enforcement post-login Action",
+		"pkce_enforcement_action_missing": "No post-login Action enforcing PKCE (code_challenge + api.access.deny) was found. This %s client is vulnerable to authorization code interception attacks.",
+		"undefined": "PKCE Enforcement is not configured."
+	},
 	"checkTokenConstrainingResourceServer": {
 		"title": "Resource Servers (APIs) - Token Sender-Constraining",
 		"category": "Resource Servers (APIs)",
@@ -1753,34 +1783,34 @@
 		"undefined": "Private Key JWT authentication method is not configured for this application"
 	},
 	"checkBackchannelLogout": {
-        "title": "Applications - Back-Channel Logout",
-        "category": "Applications",
-        "description": "Back-Channel Logout enables the identity provider to directly notify applications when a session is terminated, ensuring that all application sessions are invalidated immediately. Auth0 supports the OpenID Connect Back-Channel Logout 1.0 specification, which leverages session IDs (sid) in ID tokens and Logout Tokens to coordinate session termination via back-channel communication.",
-        "docsPath": [
-            "https://auth0.com/docs/authenticate/login/logout/back-channel-logout"
-        ],
-        "severity": "Moderate",
-        "status": "yellow",
-        "disclaimer": "Back-Channel Logout is available only to customers on an Enterprise plan subscription.",
-        "advisory": {
-            "issue": "Back-Channel Logout URI Not Configured for Application",
-            "description": {
-                "what_it_is": "Back-Channel Logout (OIDC Back-Channel Logout 1.0) allows the Auth0 tenant to directly call a pre-registered logout URI on your application server when a user session is terminated — without relying on the user's browser. The tenant sends a signed Logout Token containing the user's sub and sid claims, which the application uses to identify and terminate the corresponding local session. This enables centralized, reliable session revocation across all applications sharing the same Auth0 session.",
-                "why_its_risky": [
-                    "Without Back-Channel Logout, application sessions may remain active even after the user logs out of Auth0, leaving a window for session hijacking or unauthorized access.",
-                    "Front-channel logout relies on the user's browser completing redirects — if the browser is closed, network issues occur, or redirects are blocked, applications may never receive the logout signal.",
-                    "In multi-application environments, a logout from one application will not propagate to others without back-channel coordination, violating the principle of centralized session control."
-                ]
-            },
-            "how_to_fix": [
-                "In the Auth0 Dashboard, navigate to Applications > [Your App] > OpenID Connect Back-Channel Logout and configure a Back-Channel Logout URI that is reachable from the Auth0 tenant server.",
-                "Implement the logout endpoint to validate the incoming Logout Token: verify the issuer, audience, signature, expiry, and that the events claim contains 'http://schemas.openid.net/event/backchannel-logout'.",
-                "Store the session ID (sid) received in ID tokens during login so it can be matched against incoming Logout Tokens.",
-                "Extract the sid claim from the Logout Token and use it to locate and terminate the matching local application session."
-            ]
-        },
-        "severity_message": "%s applications do not have Back-Channel Logout configured",
-        "oidc_backchannel_logout.backchannel_logout_urls": "Back-Channel Logout is not configured for this application. Consider adding a Back-Channel Logout URI to ensure reliable session termination across all applications.",
-        "undefined": "Back-Channel Logout URI is not configured for this application"
-    }
+		"title": "Applications - Back-Channel Logout",
+		"category": "Applications",
+		"description": "Back-Channel Logout enables the identity provider to directly notify applications when a session is terminated, ensuring that all application sessions are invalidated immediately. Auth0 supports the OpenID Connect Back-Channel Logout 1.0 specification, which leverages session IDs (sid) in ID tokens and Logout Tokens to coordinate session termination via back-channel communication.",
+		"docsPath": [
+			"https://auth0.com/docs/authenticate/login/logout/back-channel-logout"
+		],
+		"severity": "Moderate",
+		"status": "yellow",
+		"disclaimer": "Back-Channel Logout is available only to customers on an Enterprise plan subscription.",
+		"advisory": {
+			"issue": "Back-Channel Logout URI Not Configured for Application",
+			"description": {
+				"what_it_is": "Back-Channel Logout (OIDC Back-Channel Logout 1.0) allows the Auth0 tenant to directly call a pre-registered logout URI on your application server when a user session is terminated — without relying on the user's browser. The tenant sends a signed Logout Token containing the user's sub and sid claims, which the application uses to identify and terminate the corresponding local session. This enables centralized, reliable session revocation across all applications sharing the same Auth0 session.",
+				"why_its_risky": [
+					"Without Back-Channel Logout, application sessions may remain active even after the user logs out of Auth0, leaving a window for session hijacking or unauthorized access.",
+					"Front-channel logout relies on the user's browser completing redirects — if the browser is closed, network issues occur, or redirects are blocked, applications may never receive the logout signal.",
+					"In multi-application environments, a logout from one application will not propagate to others without back-channel coordination, violating the principle of centralized session control."
+				]
+			},
+			"how_to_fix": [
+				"In the Auth0 Dashboard, navigate to Applications > [Your App] > OpenID Connect Back-Channel Logout and configure a Back-Channel Logout URI that is reachable from the Auth0 tenant server.",
+				"Implement the logout endpoint to validate the incoming Logout Token: verify the issuer, audience, signature, expiry, and that the events claim contains 'http://schemas.openid.net/event/backchannel-logout'.",
+				"Store the session ID (sid) received in ID tokens during login so it can be matched against incoming Logout Tokens.",
+				"Extract the sid claim from the Logout Token and use it to locate and terminate the matching local application session."
+			]
+		},
+		"severity_message": "%s applications do not have Back-Channel Logout configured",
+		"oidc_backchannel_logout.backchannel_logout_urls": "Back-Channel Logout is not configured for this application. Consider adding a Back-Channel Logout URI to ensure reliable session termination across all applications.",
+		"undefined": "Back-Channel Logout URI is not configured for this application"
+	}
 }

--- a/tests/clients/checkPKCEEnforcement.test.js
+++ b/tests/clients/checkPKCEEnforcement.test.js
@@ -1,0 +1,375 @@
+const chai = require("chai");
+const expect = chai.expect;
+const checkPKCEEnforcement = require("../../analyzer/lib/clients/checkPKCEEnforcement");
+const CONSTANTS = require("../../analyzer/lib/constants");
+
+describe("checkPKCEEnforcement", function () {
+  const pkceEnforcingAction = {
+    id: "pkce-action",
+    name: "Enforce PKCE",
+    status: "built",
+    supported_triggers: [{ id: "post-login", version: "v3" }],
+    code: `exports.onExecutePostLogin = async (event, api) => {
+      if (!event.request.query.code_challenge) {
+        api.access.deny("PKCE required");
+      }
+    };`,
+  };
+
+  it("should return empty details when no clients are provided", async function () {
+    const input = { clients: [] };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details).to.be.an("array").that.is.empty;
+  });
+
+  it("should return empty details when no applicable clients exist (regular_web only)", async function () {
+    const input = {
+      clients: [
+        {
+          name: "Web App",
+          client_id: "client_web",
+          app_type: "regular_web",
+          grant_types: ["authorization_code", "refresh_token"],
+        },
+      ],
+      actions: { actions: [pkceEnforcingAction] },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details).to.be.an("array").that.is.empty;
+  });
+
+  it("should return empty details when no applicable clients exist (non_interactive only)", async function () {
+    const input = {
+      clients: [
+        {
+          name: "M2M App",
+          client_id: "client_m2m",
+          app_type: "non_interactive",
+          grant_types: ["client_credentials"],
+        },
+      ],
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details).to.be.an("array").that.is.empty;
+  });
+
+  it("should FAIL a SPA client with authorization_code grant when no PKCE-enforcing action exists", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          is_first_party: true,
+          grant_types: ["authorization_code", "refresh_token"],
+        },
+      ],
+      actions: { actions: [] },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details).to.have.lengthOf(1);
+    expect(result.details[0].name).to.equal("My SPA (client_spa)");
+    expect(result.details[0].report).to.have.lengthOf(1);
+    expect(result.details[0].report[0]).to.include({
+      field: "pkce_enforcement_action_missing",
+      status: CONSTANTS.FAIL,
+      value: "spa",
+    });
+  });
+
+  it("should FAIL a native client with authorization_code grant when no PKCE-enforcing action exists", async function () {
+    const input = {
+      clients: [
+        {
+          name: "Mobile App",
+          client_id: "client_native",
+          app_type: "native",
+          is_first_party: true,
+          grant_types: ["authorization_code", "refresh_token"],
+        },
+      ],
+      actions: { actions: [] },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details).to.have.lengthOf(1);
+    expect(result.details[0].report[0]).to.include({
+      field: "pkce_enforcement_action_missing",
+      status: CONSTANTS.FAIL,
+      value: "native",
+    });
+  });
+
+  it("should pass (empty report) when a valid PKCE-enforcing post-login action exists", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          is_first_party: true,
+          grant_types: ["authorization_code", "refresh_token"],
+        },
+      ],
+      actions: { actions: [pkceEnforcingAction] },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details).to.have.lengthOf(1);
+    expect(result.details[0].report).to.be.an("array").that.is.empty;
+  });
+
+  it("should pass when code_challenge is accessed via an intermediate variable", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: {
+        actions: [
+          {
+            id: "pkce-indirect",
+            name: "Enforce PKCE Indirect",
+            status: "built",
+            supported_triggers: [{ id: "post-login", version: "v3" }],
+            code: `exports.onExecutePostLogin = async (event, api) => {
+              const query = event.request && event.request.query;
+              const codeChallenge = query && query.code_challenge;
+              if (!codeChallenge) {
+                api.access.deny("PKCE required");
+              }
+            };`,
+          },
+        ],
+      },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details[0].report).to.be.an("array").that.is.empty;
+  });
+
+  it("should FAIL when action checks code_challenge but has no api.access.deny call", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: {
+        actions: [
+          {
+            id: "partial-action",
+            name: "Partial PKCE",
+            supported_triggers: [{ id: "post-login", version: "v3" }],
+            code: `exports.onExecutePostLogin = async (event, api) => {
+              const challenge = event.request.query.code_challenge;
+              console.log(challenge);
+            };`,
+          },
+        ],
+      },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details[0].report[0].field).to.equal("pkce_enforcement_action_missing");
+    expect(result.details[0].report[0].status).to.equal(CONSTANTS.FAIL);
+  });
+
+  it("should FAIL when action calls api.access.deny but does not check code_challenge", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: {
+        actions: [
+          {
+            id: "deny-only-action",
+            name: "Deny Only",
+            supported_triggers: [{ id: "post-login", version: "v3" }],
+            code: `exports.onExecutePostLogin = async (event, api) => {
+              api.access.deny("blocked");
+            };`,
+          },
+        ],
+      },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details[0].report[0].field).to.equal("pkce_enforcement_action_missing");
+    expect(result.details[0].report[0].status).to.equal(CONSTANTS.FAIL);
+  });
+
+  it("should FAIL when the PKCE action is on the wrong trigger type (not post-login)", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: {
+        actions: [
+          {
+            id: "pre-reg-action",
+            name: "Pre-Registration PKCE",
+            supported_triggers: [{ id: "pre-user-registration", version: "v1" }],
+            code: `exports.onExecutePreUserRegistration = async (event, api) => {
+              if (!event.request.query.code_challenge) {
+                api.access.deny("PKCE required");
+              }
+            };`,
+          },
+        ],
+      },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details[0].report[0].field).to.equal("pkce_enforcement_action_missing");
+    expect(result.details[0].report[0].status).to.equal(CONSTANTS.FAIL);
+  });
+
+  it("should FAIL all applicable clients when no PKCE enforcement action exists", async function () {
+    const input = {
+      clients: [
+        {
+          name: "SPA One",
+          client_id: "client_spa_1",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+        {
+          name: "SPA Two",
+          client_id: "client_spa_2",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+        {
+          name: "Native App",
+          client_id: "client_native_1",
+          app_type: "native",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: { actions: [] },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details).to.have.lengthOf(3);
+    result.details.forEach((detail) => {
+      expect(detail.report[0].field).to.equal("pkce_enforcement_action_missing");
+      expect(detail.report[0].status).to.equal(CONSTANTS.FAIL);
+    });
+  });
+
+  it("should pass all applicable clients when a PKCE-enforcing action exists", async function () {
+    const input = {
+      clients: [
+        {
+          name: "SPA One",
+          client_id: "client_spa_1",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+        {
+          name: "Native App",
+          client_id: "client_native_1",
+          app_type: "native",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: { actions: [pkceEnforcingAction] },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details).to.have.lengthOf(2);
+    result.details.forEach((detail) => {
+      expect(detail.report).to.be.an("array").that.is.empty;
+    });
+  });
+
+  it("should FAIL when the PKCE-enforcing action exists but is not deployed (status !== built)", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: {
+        actions: [
+          {
+            ...pkceEnforcingAction,
+            status: "draft",
+          },
+        ],
+      },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details[0].report[0].field).to.equal("pkce_enforcement_action_missing");
+    expect(result.details[0].report[0].status).to.equal(CONSTANTS.FAIL);
+  });
+
+  it("should pass when the PKCE-enforcing action has status built", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: {
+        actions: [
+          {
+            ...pkceEnforcingAction,
+            status: "built",
+          },
+        ],
+      },
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details[0].report).to.be.an("array").that.is.empty;
+  });
+
+  it("should accept actions as a flat array (not wrapped in actions object)", async function () {
+    const input = {
+      clients: [
+        {
+          name: "My SPA",
+          client_id: "client_spa",
+          app_type: "spa",
+          grant_types: ["authorization_code"],
+        },
+      ],
+      actions: [pkceEnforcingAction],
+    };
+    const result = await checkPKCEEnforcement(input);
+    expect(result.details[0].report).to.be.an("array").that.is.empty;
+  });
+
+  it("should FAIL a SPA that only uses implicit grant (no authorization_code)", async function () {
+    const input = {
+      clients: [
+        {
+          name: "Legacy SPA",
+          client_id: "client_implicit",
+          app_type: "spa",
+          grant_types: ["implicit"],
+        },
+      ],
+      actions: { actions: [] },
+    };
+    const result = await checkPKCEEnforcement(input);
+    // implicit-only SPAs do not use authorization_code, so not applicable
+    expect(result.details).to.be.an("array").that.is.empty;
+  });
+});


### PR DESCRIPTION
This PR includes a new validator for checking that PKCE is enforced for SPA and Native apps.  

### References

See: https://support.auth0.com/center/s/article/Enforce-PKCE-with-Actions


### Testing


- [ X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ X ] All active GitHub checks for tests, formatting, and security are passing
- [ X ] The correct base branch is being used, if not the default branch
