### PR TITLE
Add API authorization policy and Management API user access checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,7 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .DS_store
+
+# Claude
+.claude/
+

--- a/analyzer/lib/resource_servers/checkAPIAuthorizationPolicy.js
+++ b/analyzer/lib/resource_servers/checkAPIAuthorizationPolicy.js
@@ -1,0 +1,81 @@
+/*
+  {
+    "id": "xxxxxxxxxxxx",
+    "name": "My API",
+    "identifier": "https://api.example.com",
+    "is_system": false,
+    "subject_type_authorization": {
+      "user": {
+        "policy": "allow_all"          // any application can mint a user token for this API
+      },
+      "client": {
+        "policy": "require_client_grant"
+      }
+    }
+  }
+
+  When the user policy is not "require_client_grant", every application in the
+  tenant is allowed to request a user access token for this API's audience. As
+  described in https://www.elttam.com/blog/exploiting-auth0-defaults-in-xss-attacks
+  this lets an XSS bug in any first-party application obtain tokens for an
+  unrelated API (e.g. an Admin API) - particularly dangerous when the back-end
+  does not validate the authorized party (`azp`) claim. Restricting API access to
+  approved applications (`require_client_grant`) and validating `azp` server-side
+  contains the blast radius of a single compromised application.
+*/
+const _ = require("lodash");
+const executeCheck = require("../executeCheck");
+const CONSTANTS = require("../constants");
+
+function getUserPolicy(api) {
+  return _.get(api, "subject_type_authorization.user.policy");
+}
+
+function checkAPIAuthorizationPolicy(options) {
+  return executeCheck("checkAPIAuthorizationPolicy", (callback) => {
+    const { resourceServers } = options || {};
+    const reports = [];
+
+    if (_.isEmpty(resourceServers)) {
+      return callback(reports);
+    }
+
+    resourceServers.forEach((api) => {
+      // The Auth0 Management API is covered by checkManagementAPIUserAccess.
+      if (api.is_system) {
+        return;
+      }
+
+      const apiDisplayName = api.identifier
+        ? `${api.name} (${api.identifier})`
+        : api.name;
+      const report = [];
+
+      if (getUserPolicy(api) === "require_client_grant") {
+        report.push({
+          name: apiDisplayName,
+          api_name: api.name,
+          field: "api_access_restricted",
+          status: CONSTANTS.SUCCESS,
+          value: api.name,
+          identifier: api.identifier,
+        });
+      } else {
+        report.push({
+          name: apiDisplayName,
+          api_name: api.name,
+          field: "api_access_unrestricted",
+          status: CONSTANTS.WARN,
+          value: api.name,
+          identifier: api.identifier,
+        });
+      }
+
+      reports.push({ name: apiDisplayName, report: report });
+    });
+
+    return callback(reports);
+  });
+}
+
+module.exports = checkAPIAuthorizationPolicy;

--- a/analyzer/lib/resource_servers/checkManagementAPIUserAccess.js
+++ b/analyzer/lib/resource_servers/checkManagementAPIUserAccess.js
@@ -1,0 +1,77 @@
+/*
+  The Auth0 Management API is exposed as a system resource server, e.g.:
+  {
+    "id": "xxxxxxxxxxxx",
+    "name": "Auth0 Management API",
+    "identifier": "https://your-tenant.us.auth0.com/api/v2/",
+    "is_system": true,
+    "subject_type_authorization": {
+      "user": {
+        "policy": "allow_all"          // permissive default -> any app's users can call /api/v2/
+      },
+      "client": {
+        "policy": "require_client_grant"
+      }
+    }
+  }
+
+  When the user policy is "allow_all" (the historical default), users of ANY
+  application in the tenant can obtain a Management API access token carrying
+  `{action}:current_user_{resource}` scopes. As described in
+  https://www.elttam.com/blog/exploiting-auth0-defaults-in-xss-attacks an
+  attacker who lands XSS in any first-party app can socially-engineer consent to
+  `update:current_user_identities` and link an attacker-controlled account to the
+  victim, gaining persistent access. Restricting user access to
+  `require_client_grant` and handling profile / account-linking through a
+  back-end machine-to-machine flow removes this vector.
+*/
+const _ = require("lodash");
+const executeCheck = require("../executeCheck");
+const CONSTANTS = require("../constants");
+
+function getUserPolicy(api) {
+  return _.get(api, "subject_type_authorization.user.policy");
+}
+
+function checkManagementAPIUserAccess(options) {
+  return executeCheck("checkManagementAPIUserAccess", (callback) => {
+    const { resourceServers } = options || {};
+    const report = [];
+
+    if (_.isEmpty(resourceServers)) {
+      return callback(report);
+    }
+
+    const managementApi = _.find(
+      resourceServers,
+      (api) =>
+        api.is_system &&
+        typeof api.identifier === "string" &&
+        api.identifier.endsWith("/api/v2/"),
+    );
+
+    if (!managementApi) {
+      return callback(report);
+    }
+
+    const name = managementApi.name || "Auth0 Management API";
+
+    if (getUserPolicy(managementApi) === "require_client_grant") {
+      report.push({
+        field: "management_api_user_access_restricted",
+        name: name,
+        status: CONSTANTS.SUCCESS,
+      });
+    } else {
+      report.push({
+        field: "management_api_user_access_allowed",
+        name: name,
+        status: CONSTANTS.FAIL,
+      });
+    }
+
+    return callback(report);
+  });
+}
+
+module.exports = checkManagementAPIUserAccess;

--- a/analyzer/report.js
+++ b/analyzer/report.js
@@ -434,6 +434,20 @@ async function generateReport(locale, tenantConfig, config) {
             cd.message = i18n.__(`${report.name}.${cd.field}`);
           });
           break;
+        case "checkManagementAPIUserAccess":
+          report.advisory = i18n.__(`${report.name}.advisory`);
+          report.details.forEach((cd) => {
+            cd.message = i18n.__(`${report.name}.${cd.field}`);
+          });
+          break;
+        case "checkAPIAuthorizationPolicy":
+          report.advisory = i18n.__(`${report.name}.advisory`);
+          report.details.forEach((detail) => {
+            detail.report.forEach((c) => {
+              c.message = i18n.__(`${report.name}.${c.field}`, c.api_name);
+            });
+          });
+          break;
         case "checkAPISigningAlgorithm":
         case "checkAPITokenLifetime":
           report.advisory = i18n.__(`${report.name}.advisory`);

--- a/locales/en.json
+++ b/locales/en.json
@@ -172,7 +172,9 @@
 				"Signing Algorithm",
 				"Token Lifetime",
 				"JSON Web Encryption (JWE)",
-				"Token Sender-Constraining"
+				"Token Sender-Constraining",
+				"API Authorization Policy",
+				"Management API User Access"
 			]
 		}
 	],
@@ -1527,6 +1529,65 @@
 			"https://auth0.com/docs/customize/events/events-best-practices",
 			"https://auth0.com/docs/customize/events/event-testing-observability-and-failure-recovery"
 		]
+	},
+	"checkManagementAPIUserAccess": {
+		"title": "Resource Servers (APIs) - Management API User Access",
+		"category": "Resource Servers (APIs)",
+		"description": "Validates whether end users of arbitrary applications are allowed to obtain Auth0 Management API access tokens. By default the Management API permits user access from all applications, which exposes sensitive self-service scopes such as update:current_user_identities.",
+		"docsPath": [
+			"https://auth0.com/docs/manage-users/user-accounts/user-account-linking",
+			"https://auth0.com/docs/secure/tokens/access-tokens/get-management-api-access-tokens-for-single-page-applications",
+			"https://www.elttam.com/blog/exploiting-auth0-defaults-in-xss-attacks"
+		],
+		"severity": "High",
+		"status": "red",
+		"severity_message": "Management API user access is not restricted to approved applications.",
+		"advisory": {
+			"issue": "Management API User Access Enabled for All Applications",
+			"description": {
+				"what_it_is": "The Auth0 Management API can issue access tokens to end users via the {action}:current_user_{resource} scopes. By default this user access is allowed from every application in the tenant.",
+				"why_its_risky": [
+					"An attacker who achieves XSS in any first-party application can request a Management API token on behalf of the logged-in user. The consent prompt appears to come from a trusted application, increasing the chance the victim approves it.",
+					"With the update:current_user_identities scope an attacker can link an attacker-controlled account to the victim's account (POST /api/v2/users/{id}/identities), establishing persistent, unauthorized access that survives password changes."
+				]
+			},
+			"how_to_fix": [
+				"Restrict Management API user access by setting the user subject-type authorization policy to require_client_grant so only approved applications can obtain Management API tokens.",
+				"Perform profile updates and account linking from a back-end using machine-to-machine (client credentials) authentication instead of exposing those scopes to browser-based applications.",
+				"Require an additional authentication challenge (step-up MFA) before sensitive operations such as account linking or password changes."
+			]
+		},
+		"management_api_user_access_allowed": "The Auth0 Management API allows user access from all applications. Restrict user access to approved applications (require_client_grant) and handle account linking / profile updates via a back-end machine-to-machine flow.",
+		"management_api_user_access_restricted": "Management API user access is restricted to approved applications (require_client_grant)."
+	},
+	"checkAPIAuthorizationPolicy": {
+		"title": "Resource Servers (APIs) - API Authorization Policy",
+		"category": "Resource Servers (APIs)",
+		"description": "Validates that each API restricts which applications can obtain user access tokens for it. Allowing all applications to request tokens for an API lets an XSS bug in one application mint tokens for an unrelated API.",
+		"docsPath": [
+			"https://auth0.com/docs/get-started/apis/api-settings",
+			"https://auth0.com/docs/secure/tokens/access-tokens/validate-access-tokens",
+			"https://www.elttam.com/blog/exploiting-auth0-defaults-in-xss-attacks"
+		],
+		"severity": "Moderate",
+		"status": "yellow",
+		"severity_message": "%s API(s) allow user access tokens to be issued to all applications.",
+		"advisory": {
+			"issue": "API Access Not Restricted to Approved Applications",
+			"description": {
+				"what_it_is": "An API's authorization policy controls which applications can request user access tokens for its audience. When the policy allows all applications, any client in the tenant can obtain a token for the API.",
+				"why_its_risky": [
+					"An XSS vulnerability in one application can initiate an authorization request for a different API's audience and exfiltrate the resulting access token.",
+					"The risk is amplified when the API back-end does not validate the authorized party (azp) claim, because it cannot tell which application the token was issued to."
+				]
+			},
+			"how_to_fix": [
+				"Restrict API access to approved applications by setting the user subject-type authorization policy to require_client_grant.",
+				"Validate the azp claim against an allowlist of approved client IDs in the API back-end."
+			]
+		},
+		"api_access_unrestricted": "API \"%s\" allows user access tokens to be issued to all applications. Restrict access to approved applications (require_client_grant) and validate the azp claim in your API.",
+		"api_access_restricted": "API \"%s\" restricts user access tokens to approved applications (require_client_grant)."
 	},
 	"checkAPISigningAlgorithm": {
 		"title": "Resource Servers (APIs) - Signing Algorithm",

--- a/tests/resource_servers/checkAPIAuthorizationPolicy.test.js
+++ b/tests/resource_servers/checkAPIAuthorizationPolicy.test.js
@@ -1,0 +1,117 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const checkAPIAuthorizationPolicy = require("../../analyzer/lib/resource_servers/checkAPIAuthorizationPolicy");
+const CONSTANTS = require("../../analyzer/lib/constants");
+
+describe("checkAPIAuthorizationPolicy", function () {
+  it("should return an empty report when resourceServers is empty", async function () {
+    const result = await checkAPIAuthorizationPolicy({ resourceServers: [] });
+    expect(result.details).to.deep.equal([]);
+  });
+
+  it("should return an empty report when resourceServers is undefined", async function () {
+    const result = await checkAPIAuthorizationPolicy({
+      resourceServers: undefined,
+    });
+    expect(result.details).to.deep.equal([]);
+  });
+
+  it("should skip the system Management API", async function () {
+    const result = await checkAPIAuthorizationPolicy({
+      resourceServers: [
+        {
+          id: "system_api",
+          name: "Auth0 Management API",
+          identifier: "https://tenant.us.auth0.com/api/v2/",
+          is_system: true,
+          subject_type_authorization: { user: { policy: "allow_all" } },
+        },
+      ],
+    });
+    expect(result.details).to.deep.equal([]);
+  });
+
+  it("should warn when API user access policy is allow_all", async function () {
+    const result = await checkAPIAuthorizationPolicy({
+      resourceServers: [
+        {
+          id: "api_1",
+          name: "My API",
+          identifier: "https://api.example.com",
+          is_system: false,
+          subject_type_authorization: {
+            user: { policy: "allow_all" },
+            client: { policy: "require_client_grant" },
+          },
+        },
+      ],
+    });
+    const report = result.details[0].report;
+    expect(report).to.have.lengthOf(1);
+    expect(report[0].field).to.equal("api_access_unrestricted");
+    expect(report[0].status).to.equal(CONSTANTS.WARN);
+  });
+
+  it("should warn when the user policy is absent (permissive default)", async function () {
+    const result = await checkAPIAuthorizationPolicy({
+      resourceServers: [
+        {
+          id: "api_1",
+          name: "My API",
+          identifier: "https://api.example.com",
+          is_system: false,
+        },
+      ],
+    });
+    expect(result.details[0].report[0].field).to.equal("api_access_unrestricted");
+    expect(result.details[0].report[0].status).to.equal(CONSTANTS.WARN);
+  });
+
+  it("should pass when the user policy is require_client_grant", async function () {
+    const result = await checkAPIAuthorizationPolicy({
+      resourceServers: [
+        {
+          id: "api_1",
+          name: "My API",
+          identifier: "https://api.example.com",
+          is_system: false,
+          subject_type_authorization: {
+            user: { policy: "require_client_grant" },
+            client: { policy: "require_client_grant" },
+          },
+        },
+      ],
+    });
+    expect(result.details[0].report[0].field).to.equal("api_access_restricted");
+    expect(result.details[0].report[0].status).to.equal(CONSTANTS.SUCCESS);
+  });
+
+  it("should handle multiple APIs independently", async function () {
+    const result = await checkAPIAuthorizationPolicy({
+      resourceServers: [
+        {
+          id: "api_1",
+          name: "Restricted API",
+          identifier: "https://restricted.api.com",
+          is_system: false,
+          subject_type_authorization: { user: { policy: "require_client_grant" } },
+        },
+        {
+          id: "api_2",
+          name: "Open API",
+          identifier: "https://open.api.com",
+          is_system: false,
+          subject_type_authorization: { user: { policy: "allow_all" } },
+        },
+      ],
+    });
+    expect(result.details).to.have.lengthOf(2);
+
+    const restricted = result.details.find((d) => d.name.includes("Restricted API"));
+    expect(restricted.report[0].status).to.equal(CONSTANTS.SUCCESS);
+
+    const open = result.details.find((d) => d.name.includes("Open API"));
+    expect(open.report[0].status).to.equal(CONSTANTS.WARN);
+  });
+});

--- a/tests/resource_servers/checkManagementAPIUserAccess.test.js
+++ b/tests/resource_servers/checkManagementAPIUserAccess.test.js
@@ -1,0 +1,94 @@
+const chai = require("chai");
+const expect = chai.expect;
+
+const checkManagementAPIUserAccess = require("../../analyzer/lib/resource_servers/checkManagementAPIUserAccess");
+const CONSTANTS = require("../../analyzer/lib/constants");
+
+const MGMT_IDENTIFIER = "https://tenant.us.auth0.com/api/v2/";
+
+describe("checkManagementAPIUserAccess", function () {
+  it("should return an empty report when resourceServers is empty", async function () {
+    const result = await checkManagementAPIUserAccess({ resourceServers: [] });
+    expect(result.details).to.deep.equal([]);
+  });
+
+  it("should return an empty report when resourceServers is undefined", async function () {
+    const result = await checkManagementAPIUserAccess({
+      resourceServers: undefined,
+    });
+    expect(result.details).to.deep.equal([]);
+  });
+
+  it("should return an empty report when the Management API is not present", async function () {
+    const result = await checkManagementAPIUserAccess({
+      resourceServers: [
+        {
+          id: "api_1",
+          name: "My API",
+          identifier: "https://api.example.com",
+          is_system: false,
+        },
+      ],
+    });
+    expect(result.details).to.deep.equal([]);
+  });
+
+  it("should fail when Management API user access policy is allow_all", async function () {
+    const result = await checkManagementAPIUserAccess({
+      resourceServers: [
+        {
+          id: "system_api",
+          name: "Auth0 Management API",
+          identifier: MGMT_IDENTIFIER,
+          is_system: true,
+          subject_type_authorization: {
+            user: { policy: "allow_all" },
+            client: { policy: "require_client_grant" },
+          },
+        },
+      ],
+    });
+    const report = result.details;
+    expect(report).to.have.lengthOf(1);
+    expect(report[0].field).to.equal("management_api_user_access_allowed");
+    expect(report[0].status).to.equal(CONSTANTS.FAIL);
+  });
+
+  it("should fail when the user policy is absent (permissive default)", async function () {
+    const result = await checkManagementAPIUserAccess({
+      resourceServers: [
+        {
+          id: "system_api",
+          name: "Auth0 Management API",
+          identifier: MGMT_IDENTIFIER,
+          is_system: true,
+        },
+      ],
+    });
+    expect(result.details[0].field).to.equal(
+      "management_api_user_access_allowed",
+    );
+    expect(result.details[0].status).to.equal(CONSTANTS.FAIL);
+  });
+
+  it("should pass when the user policy is require_client_grant", async function () {
+    const result = await checkManagementAPIUserAccess({
+      resourceServers: [
+        {
+          id: "system_api",
+          name: "Auth0 Management API",
+          identifier: MGMT_IDENTIFIER,
+          is_system: true,
+          subject_type_authorization: {
+            user: { policy: "require_client_grant" },
+            client: { policy: "require_client_grant" },
+          },
+        },
+      ],
+    });
+    expect(result.details[0].field).to.equal(
+      "management_api_user_access_restricted",
+    );
+    expect(result.details[0].status).to.equal(CONSTANTS.SUCCESS);
+  });
+});


### PR DESCRIPTION
### Description

This PR adds two new resource server checks that surface the potentially insecure Auth0 "allow_all" authorization-policy defaults.

- checkManagementAPIUserAccess: flags when the Management API issues user access tokens to all applications, exposing update:current_user_identities and enabling persistent account-linking attacks.
- checkAPIAuthorizationPolicy: flags non-system APIs whose user subject-type policy is not require_client_grant, letting any client mint tokens for an unrelated API.

It wires both into report.js i18n handling and add en.json advisory copy, severity messages, and report headings. Add test coverage for both checks. Also gitignore the local .claude/ directory.


### References

https://www.elttam.com/blog/exploiting-auth0-defaults-in-xss-attacks

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

In addition to the automated tests in this PR, it should be validated against test tenants with adequate rate limiting and configurations.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
