### PR TITLE
feat: Add support for custom Auth0 domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ To use CheckMate for Auth0, you need a **dedicated Auth0 Application** to author
    ```text
     AUTH0CHECKMATE_DISABLE_PDF_REPORTING=true|false
     AUTH0CHECKMATE_DOMAIN=your_domain
+    AUTH0CHECKMATE_AUDIENCE=your_management_api_audience # if custom domain is used
     AUTH0CHECKMATE_CLIENT_ID=your_client_id
     AUTH0CHECKMATE_CLIENT_SECRET=your_client_secret
     AUTH0CHECKMATE_FILE_PATH="./reports"

--- a/analyzer/report.js
+++ b/analyzer/report.js
@@ -88,6 +88,7 @@ async function generateReport(locale, tenantConfig, config) {
       if (!config.auth0MgmtToken) {
         config.auth0MgmtToken = await getAccessToken(
           config.auth0Domain,
+          config.auth0Audience,
           config.auth0ClientId,
           config.auth0ClientSecret,
           config.auth0MgmtToken,

--- a/analyzer/tools/auth0.js
+++ b/analyzer/tools/auth0.js
@@ -56,7 +56,7 @@ axios.interceptors.response.use(
   }
 );
 
-async function getAccessToken(domain, client_id, client_secret, access_token) {
+async function getAccessToken(domain, audience, client_id, client_secret, access_token) {
   if (access_token) {
     return access_token;
   }
@@ -70,7 +70,7 @@ async function getAccessToken(domain, client_id, client_secret, access_token) {
     grant_type: "client_credentials",
     client_id: client_id,
     client_secret: client_secret,
-    audience: `https://${domain}/api/v2/`,
+    audience: audience,
     scopes: CONSTANTS.REQUIRED_SCOPES,
   };
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -293,9 +293,10 @@ async function main() {
 
   // Check for Environment Variables
   const envDomain = process.env.AUTH0CHECKMATE_DOMAIN;
+  const envAudience = process.env.AUTH0CHECKMATE_AUDIENCE || `https://${envDomain}/api/v2/`; // Use default Auth0 Management API audience if not provided.
   const envClientId = process.env.AUTH0CHECKMATE_CLIENT_ID;
   const envClientSecret = process.env.AUTH0CHECKMATE_CLIENT_SECRET;
-  const envAuthReady = envDomain && envClientId && envClientSecret;
+  const envAuthReady = envDomain && envClientId && envClientSecret && envAudience;
   const envFilePath = process.env.AUTH0CHECKMATE_FILE_PATH; 
   const envShowValidators = process.env.AUTH0CHECKMATE_SHOW_VALIDATORS;
   let defaultShowValidators = null;
@@ -337,12 +338,13 @@ if (answers.showValidators) {
     answers.auth0Domain = envDomain;
     answers.auth0ClientId = envClientId;
     answers.auth0ClientSecret = envClientSecret;
+    answers.auth0Audience = envAudience;
 
     console.log(chalk.green(`\n✅  Using credentials from environment variables (Domain: ${envDomain}) to authenticate.`));
     
     try {
       // Get the token using the env vars
-      const accessToken = await getAccessToken(envDomain, envClientId, envClientSecret);
+      const accessToken = await getAccessToken(envDomain, envAudience, envClientId, envClientSecret);
       checkScopes(accessToken, CONSTANTS.REQUIRED_SCOPES.split(' '));
       answers.auth0MgmtToken = accessToken;
     } catch (e) {
@@ -375,7 +377,19 @@ if (answers.showValidators) {
     });
     answers.auth0Domain = auth0Domain;
 
-    // Prompt 4: Auth0 Client ID (if needed)
+    // Prompt 4: Auth0 Management API Audience (if needed)
+    if (authMethod === "clientSecret") {
+      const { auth0Audience } = await inquirer.prompt({
+        type: "input",
+        name: "auth0Audience",
+        message: "Enter your Auth0 Management API Audience:",
+        default: `https://${auth0Domain}/api/v2/`,
+        validate: (input) => (input?.match(/^https:\/\/.+\.auth0\.com\/api\/v2\/$/) ? true : "Auth0 Management API Audience is required (e.g. https://your-tenant.auth0.com/api/v2/)."),
+      });
+      answers.auth0Audience = auth0Audience;
+    }
+
+    // Prompt 5: Auth0 Client ID (if needed)
     if (authMethod === "clientSecret") {
       const { auth0ClientId } = await inquirer.prompt({
         type: "input",
@@ -386,7 +400,7 @@ if (answers.showValidators) {
       answers.auth0ClientId = auth0ClientId;
     }
 
-    // Prompt 5: Auth0 Client Secret (if needed)
+    // Prompt 6: Auth0 Client Secret (if needed)
     if (authMethod === "clientSecret") {
       const { auth0ClientSecret } = await inquirer.prompt({
         type: "password",
@@ -396,7 +410,7 @@ if (answers.showValidators) {
       });
       answers.auth0ClientSecret = auth0ClientSecret;
       try {
-        const accessToken = await getAccessToken(answers.auth0Domain, answers.auth0ClientId, answers.auth0ClientSecret);
+        const accessToken = await getAccessToken(answers.auth0Domain, answers.auth0Audience, answers.auth0ClientId, answers.auth0ClientSecret);
         checkScopes(accessToken, CONSTANTS.REQUIRED_SCOPES.split(' '));
         answers.auth0MgmtToken = accessToken;
       } catch (e) {
@@ -405,7 +419,7 @@ if (answers.showValidators) {
       }
     }
 
-    // Prompt 6: Auth0 Management Token (if needed)
+    // Prompt 7: Auth0 Management Token (if needed)
     if (authMethod === "auth0MgmtToken") {
       const { auth0MgmtToken } = await inquirer.prompt({
         type: "input",
@@ -419,7 +433,7 @@ if (answers.showValidators) {
     }
   }
 
-  // Prompt 7: Locale (if more than one)
+  // Prompt 8: Locale (if more than one)
   const locales = i18n.getLocales();
   if (locales.length > 1) {
     const { locale } = await inquirer.prompt({
@@ -434,7 +448,7 @@ if (answers.showValidators) {
     answers.locale = "en";
   }
 
-  // Prompt 8: File path
+  // Prompt 9: File path
   if (envFilePath) {
     // A. Use environment variable directly (non-interactive)
     answers.filePath = envFilePath;
@@ -460,6 +474,7 @@ if (answers.showValidators) {
   // Construct config
   const config = {
     auth0Domain: answers.auth0Domain,
+    auth0Audience: answers.auth0Audience,
     auth0ClientId: answers.auth0ClientId || null,
     auth0ClientSecret: answers.auth0ClientSecret || null,
     auth0MgmtToken: answers.auth0MgmtToken || null,

--- a/tests/tools/auth0.test.js
+++ b/tests/tools/auth0.test.js
@@ -67,7 +67,7 @@ describe("auth0.js", function() {
     it("should return existing access token when provided", async function() {
       const existingToken = "existing-token-123";
       
-      const result = await getAccessToken("test-domain", "client-id", "client-secret", existingToken);
+      const result = await getAccessToken("test-domain", "test-audience", "client-id", "client-secret", existingToken);
 
       expect(result).to.equal(existingToken);
     });
@@ -86,11 +86,11 @@ describe("auth0.js", function() {
         expect(body.grant_type).to.equal("client_credentials");
         expect(body.client_id).to.equal("test-client-id");
         expect(body.client_secret).to.equal("test-client-secret");
-        expect(body.audience).to.equal("https://test-domain/api/v2/");
+        expect(body.audience).to.equal("https://test-audience/api/v2/");
         return mockResponse;
       };
 
-      const result = await getAccessToken("test-domain", "test-client-id", "test-client-secret");
+      const result = await getAccessToken("test-domain", "https://test-audience/api/v2/", "test-client-id", "test-client-secret");
 
       expect(result).to.equal("test-access-token");
     });
@@ -101,7 +101,7 @@ describe("auth0.js", function() {
       };
 
       try {
-        await getAccessToken("test-domain", "test-client-id", "wrong-secret");
+        await getAccessToken("test-domain", "https://test-audience/api/v2/", "test-client-id", "wrong-secret");
         expect.fail("Should have thrown an error");
       } catch (error) {
         expect(error.message).to.contain("process.exit called with code 1");


### PR DESCRIPTION
### Description

This PR adds support for a new environment-variable&prompt for setting an audience that is not based off of the auth0 domain. This allows auth0-checkmate to be run with a custom domain instead of the canonical auth0-domain, since the canonical auth0-domain may be blocked via network ACLs. The Auth0 Management API audience is controlled by Auth0, and thus will always be in the format `https://<tenant-name>.<region-identifier>.auth0.com/api/v2/` (where `region-identifier` is optional), but the custom-domains can be anything, like `login.travel0.com`

### References

- GitHub Issue: https://github.com/auth0/auth0-checkmate/issues/134
- Auth0 Network ACL: https://auth0.com/docs/secure/tenant-access-control-list
- Example Network ACL that blocks canonical auth0 domain: https://auth0.com/docs/secure/tenant-access-control-list/use-cases#enforce-traffic-through-specific-infrastructure

### Testing

I have not added tests for the reading of the environment-variables or the prompts during CLI-run, as there are no tests for those files at all today.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch

This PR was pair-programmed by me and @etameem